### PR TITLE
man: Correct rpc.gssd(8) description of rpc-timeout and context-timeout

### DIFF
--- a/utils/gssd/gssd.man
+++ b/utils/gssd/gssd.man
@@ -322,11 +322,11 @@ Equivalent to
 .TP
 .B context-timeout
 Equivalent to
-.BR -T .
+.BR -t .
 .TP
 .B rpc-timeout
 Equivalent to
-.BR -t .
+.BR -T .
 .TP
 .B keytab-file
 Equivalent to


### PR DESCRIPTION
The rpc-timeout is equivalent to -T and context-timeout to -t options,
not vice versa.